### PR TITLE
Refactor issue data handling in BlockExtension

### DIFF
--- a/extensions/issue-tracker-block/src/BlockExtension.jsx
+++ b/extensions/issue-tracker-block/src/BlockExtension.jsx
@@ -34,14 +34,12 @@ export default async () => {
         const productData = await getIssues(productId);
 
         setLoading(false);
-        if (productData?.data?.product?.metafield?.value) {
-          const parsedIssues = JSON.parse(
-            productData.data.product.metafield.value,
-          );
+        if (productData) {
+          // productData is returned from getIssues() as the parsed metafield value 
           setInitialValues(
-            parsedIssues.map(({ completed }) => Boolean(completed)),
+            productData.map(({ completed }) => Boolean(completed)),
           );
-          setIssues(parsedIssues);
+          setIssues(productData);
         }
       })();
     }, [productId]);


### PR DESCRIPTION
Demo Block wasn't working as the original function mismatched with the return value of the getIssues function. getIssues function already returned the parsed metafield value. But the code was trying to extract and parse it again.