### PR TITLE
Fix syntax error in connect extension entry points

### DIFF
--- a/extensions/issue-tracker-action/src/ActionExtension-connect.jsx
+++ b/extensions/issue-tracker-action/src/ActionExtension-connect.jsx
@@ -2,7 +2,7 @@ import { render } from "preact";
 import { useCallback, useEffect, useState } from "preact/hooks";
 import { getIssues, updateIssues } from "./utils";
 
-export default async () => { {
+export default async () => {
   render(<Extension />, document.body);
 }
 

--- a/extensions/issue-tracker-block/src/BlockExtension-connect.jsx
+++ b/extensions/issue-tracker-block/src/BlockExtension-connect.jsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from "preact/hooks";
 
 import { updateIssues, getIssues } from "./utils";
 
-export default async () => { {
+export default async () => {
   render(<Extension />, document.body);
 }
 const PAGE_SIZE = 3;


### PR DESCRIPTION
## Summary

- Both `ActionExtension-connect.jsx` and `BlockExtension-connect.jsx` had a stray extra `{` on the default export line, producing `async () => { {` instead of `async () => {`
- The extra `{` opened an inner block statement; the single `}` that followed closed only that inner block, leaving the outer async function body unclosed
- This makes both files syntactically invalid — they will fail to parse in any bundler/transpiler

## Fix

Removed the extra `{` in both files.

## Test plan

- [ ] Verify `shopify app dev` starts without parse errors
- [ ] Confirm the connect extension tutorial flow works end-to-end (block launches action with `issueId`, action pre-populates the form)