### PR TITLE
Fix stray extra { in default export across connect extension files

### DIFF
--- a/extensions/issue-tracker-action/src/ActionExtension-backend.jsx
+++ b/extensions/issue-tracker-action/src/ActionExtension-backend.jsx
@@ -2,7 +2,7 @@ import { render } from "preact";
 import { useCallback, useEffect, useState } from "preact/hooks";
 import { getIssues, updateIssues } from "./utils";
 
-export default async () => { {
+export default async () => {
   render(<Extension />, document.body);
 }
 


### PR DESCRIPTION
## Summary

- `ActionExtension-connect.jsx`, `BlockExtension-connect.jsx`, and `ActionExtension-backend.jsx` all had a stray extra `{` on the `export default async () => {` line, making the async function body syntactically invalid
- The first two files were fixed in a previous commit; this PR catches the missed `ActionExtension-backend.jsx` as well
- `ActionExtension-backend.jsx` is the source for the code snippet shown in the [Connect UI extensions to your app's backend](https://shopify.dev/docs/apps/build/admin/actions-blocks/connect-app-backend) tutorial, so this was causing the docs to display broken code

## Test plan

- [ ] Verify `ActionExtension-backend.jsx` parses without syntax errors
- [ ] Confirm the tutorial page on shopify.dev renders the corrected snippet

🤖 Generated with [Claude Code](https://claude.com/claude-code)