### PR TITLE
Fix translation key mismatches in ActionExtension-connect and ActionExtension-backend

### DIFF
--- a/extensions/issue-tracker-action/src/ActionExtension-backend.jsx
+++ b/extensions/issue-tracker-action/src/ActionExtension-backend.jsx
@@ -130,12 +130,12 @@ function Extension() {
     >
       <s-button slot="primaryAction" onClick={onSubmit}>
         {isEditing
-          ? i18n.translate("save-button")
-          : i18n.translate("create-button")}
+          ? i18n.translate("issue-save-button")
+          : i18n.translate("issue-create-button")}
       </s-button>
 
       <s-button slot="secondaryActions" onClick={close}>
-        {i18n.translate("cancel-button")}
+        {i18n.translate("issue-cancel-button")}
       </s-button>
 
       {/*Create a banner to let the buyer auto fill the issue with the

--- a/extensions/issue-tracker-action/src/ActionExtension-connect.jsx
+++ b/extensions/issue-tracker-action/src/ActionExtension-connect.jsx
@@ -111,11 +111,11 @@ function Extension() {
     >
       <s-button slot="primaryAction" onClick={onSubmit}>
         {isEditing
-          ? i18n.translate("save-button")
-          : i18n.translate("create-button")}
+          ? i18n.translate("issue-save-button")
+          : i18n.translate("issue-create-button")}
       </s-button>
       <s-button slot="secondaryActions" onClick={close}>
-        {i18n.translate("cancel-button")}
+        {i18n.translate("issue-cancel-button")}
       </s-button>
       <s-text-field
         value={title}


### PR DESCRIPTION
## Summary

- `ActionExtension-connect.jsx` and `ActionExtension-backend.jsx` used bare i18n keys (`create-button`, `cancel-button`, `save-button`) that don't exist in `en.default.json`
- At runtime this renders as `MISSING KEY for locale 'en': 'create-button'` etc. in the UI
- Fixed to use the correct keys (`issue-create-button`, `issue-cancel-button`, `issue-save-button`), matching `ActionExtension.jsx` and the locale file

## Before:

<img width="870" height="497" alt="image" src="https://github.com/user-attachments/assets/52a24feb-4f70-46f2-89e1-37aa138a1265" />

## After:

<img width="1512" height="903" alt="image" src="https://github.com/user-attachments/assets/7d1365fb-72aa-4f01-b3e7-ab31a65eada1" />

## Test plan

- [ ] Verify button labels render correctly ("Create", "Cancel", "Save") in the action extension UI
- [ ] Confirm no MISSING KEY errors appear at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)