### PR TITLE
Fix slot names, s-select value, 2026-04 upgrade, and TypeScript errors

### DIFF
--- a/extensions/admin-print/package.json
+++ b/extensions/admin-print/package.json
@@ -5,6 +5,6 @@
   "license": "UNLICENSED",
   "dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "2025-10"
+    "@shopify/ui-extensions": "2026-04"
   }
 }

--- a/extensions/admin-print/shopify.extension.toml
+++ b/extensions/admin-print/shopify.extension.toml
@@ -1,5 +1,5 @@
 # [START print-action-extension.configuration]
-api_version = "2025-10"
+api_version = "2026-04"
 [[extensions]]
 name = "admin-print"
 handle = "admin-print"

--- a/extensions/admin-print/src/PrintActionExtension.jsx
+++ b/extensions/admin-print/src/PrintActionExtension.jsx
@@ -61,16 +61,16 @@ export default async () => {
           <s-checkbox
             name="Invoice"
             checked={printInvoice}
-            onChange={(value) => {
-              setPrintInvoice(value);
+            onChange={(event) => {
+              setPrintInvoice((/** @type {HTMLInputElement} */ (event.target)).checked);
             }}
             label={i18n.translate("invoice")}
           ></s-checkbox>
           <s-checkbox
             name="Packing Slips"
             checked={printPackingSlip}
-            onChange={(value) => {
-              setPrintPackingSlip(value);
+            onChange={(event) => {
+              setPrintPackingSlip((/** @type {HTMLInputElement} */ (event.target)).checked);
             }}
             label={i18n.translate("packingSlip")}
           ></s-checkbox>

--- a/extensions/issue-tracker-action/package.json
+++ b/extensions/issue-tracker-action/package.json
@@ -4,5 +4,5 @@
   "version": "1.0.0",
   "license": "UNLICENSED","dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "2025-10"
+    "@shopify/ui-extensions": "2026-04"
   }}

--- a/extensions/issue-tracker-action/shopify.d.ts
+++ b/extensions/issue-tracker-action/shopify.d.ts
@@ -5,3 +5,15 @@ declare module "./src/ActionExtension.jsx" {
   const shopify: import("@shopify/ui-extensions/admin.product-details.action.render").Api;
   const globalThis: { shopify: typeof shopify };
 }
+
+//@ts-ignore
+declare module "./src/ActionExtension-connect.jsx" {
+  const shopify: import("@shopify/ui-extensions/admin.product-details.action.render").Api;
+  const globalThis: { shopify: typeof shopify };
+}
+
+//@ts-ignore
+declare module "./src/ActionExtension-backend.jsx" {
+  const shopify: import("@shopify/ui-extensions/admin.product-details.action.render").Api;
+  const globalThis: { shopify: typeof shopify };
+}

--- a/extensions/issue-tracker-action/shopify.extension.toml
+++ b/extensions/issue-tracker-action/shopify.extension.toml
@@ -1,5 +1,5 @@
 # [START action-extension.configuration]
-api_version = "2025-10"
+api_version = "2026-04"
 
 [[extensions]]
 # Change the merchant-facing name of the extension in locales/en.default.json

--- a/extensions/issue-tracker-action/src/ActionExtension-backend.jsx
+++ b/extensions/issue-tracker-action/src/ActionExtension-backend.jsx
@@ -122,7 +122,7 @@ function Extension() {
 
   return (
     <s-admin-action
-      title={
+      heading={
         isEditing
           ? i18n.translate("edit-issue-heading")
           : i18n.translate("create-issue-heading")
@@ -164,7 +164,7 @@ function Extension() {
           formErrors?.title ? i18n.translate("issue-title-error") : undefined
         }
         onChange={(event) =>
-          setIssue((prev) => ({ ...prev, title: event.target.value }))
+          setIssue((prev) => ({ ...prev, title: (/** @type {HTMLInputElement} */ (event.target)).value }))
         }
         label={i18n.translate("issue-title-label")}
         maxLength={50}
@@ -178,7 +178,7 @@ function Extension() {
               : undefined
           }
           onChange={(event) =>
-            setIssue((prev) => ({ ...prev, description: event.target.value }))
+            setIssue((prev) => ({ ...prev, description: (/** @type {HTMLInputElement} */ (event.target)).value }))
           }
           label={i18n.translate("issue-description-label")}
           max-length={300}

--- a/extensions/issue-tracker-action/src/ActionExtension-backend.jsx
+++ b/extensions/issue-tracker-action/src/ActionExtension-backend.jsx
@@ -128,13 +128,13 @@ function Extension() {
           : i18n.translate("create-issue-heading")
       }
     >
-      <s-button slot="primaryAction" onClick={onSubmit}>
+      <s-button slot="primary-action" onClick={onSubmit}>
         {isEditing
           ? i18n.translate("issue-save-button")
           : i18n.translate("issue-create-button")}
       </s-button>
 
-      <s-button slot="secondaryActions" onClick={close}>
+      <s-button slot="secondary-actions" onClick={close}>
         {i18n.translate("issue-cancel-button")}
       </s-button>
 

--- a/extensions/issue-tracker-action/src/ActionExtension-connect.jsx
+++ b/extensions/issue-tracker-action/src/ActionExtension-connect.jsx
@@ -123,7 +123,7 @@ function Extension() {
           formErrors?.title ? i18n.translate("issue-title-error") : undefined
         }
         onChange={(event) =>
-          setIssue((prev) => ({ ...prev, title: event.target.value }))
+          setIssue((prev) => ({ ...prev, title: (/** @type {HTMLInputElement} */ (event.target)).value }))
         }
         label={i18n.translate("issue-title-label")}
         maxLength={50}
@@ -137,7 +137,7 @@ function Extension() {
               : undefined
           }
           onChange={(event) =>
-            setIssue((prev) => ({ ...prev, description: event.target.value }))
+            setIssue((prev) => ({ ...prev, description: (/** @type {HTMLInputElement} */ (event.target)).value }))
           }
           label={i18n.translate("issue-description-label")}
           max-length={300}

--- a/extensions/issue-tracker-action/src/ActionExtension-connect.jsx
+++ b/extensions/issue-tracker-action/src/ActionExtension-connect.jsx
@@ -109,12 +109,12 @@ function Extension() {
           : i18n.translate("create-issue-heading")
       }
     >
-      <s-button slot="primaryAction" onClick={onSubmit}>
+      <s-button slot="primary-action" onClick={onSubmit}>
         {isEditing
           ? i18n.translate("issue-save-button")
           : i18n.translate("issue-create-button")}
       </s-button>
-      <s-button slot="secondaryActions" onClick={close}>
+      <s-button slot="secondary-actions" onClick={close}>
         {i18n.translate("issue-cancel-button")}
       </s-button>
       <s-text-field

--- a/extensions/issue-tracker-action/src/ActionExtension.jsx
+++ b/extensions/issue-tracker-action/src/ActionExtension.jsx
@@ -65,10 +65,10 @@ export default async () => {
     // [START build-admin-action.create-ui-three]
     return (
       <s-admin-action heading={i18n.translate("name")}>
-        <s-button slot="primaryAction" onClick={onSubmit}>
+        <s-button slot="primary-action" onClick={onSubmit}>
           {i18n.translate("issue-create-button")}
         </s-button>
-        <s-button slot="secondaryActions" onClick={close}>
+        <s-button slot="secondary-actions" onClick={close}>
           {i18n.translate("issue-cancel-button")}
         </s-button>
         <s-text-field

--- a/extensions/issue-tracker-action/src/ActionExtension.jsx
+++ b/extensions/issue-tracker-action/src/ActionExtension.jsx
@@ -77,7 +77,7 @@ export default async () => {
             formErrors?.title ? i18n.translate("issue-title-error") : undefined
           }
           onChange={(event) =>
-            setIssue((prev) => ({ ...prev, title: event.target.value }))
+            setIssue((prev) => ({ ...prev, title: (/** @type {HTMLInputElement} */ (event.target)).value }))
           }
           label={i18n.translate("issue-title-label")}
           maxLength={50}
@@ -91,7 +91,7 @@ export default async () => {
                 : undefined
             }
             onChange={(event) =>
-              setIssue((prev) => ({ ...prev, description: event.target.value }))
+              setIssue((prev) => ({ ...prev, description: (/** @type {HTMLInputElement} */ (event.target)).value }))
             }
             label={i18n.translate("issue-description-label")}
             max-length={300}

--- a/extensions/issue-tracker-block/package.json
+++ b/extensions/issue-tracker-block/package.json
@@ -4,5 +4,5 @@
   "version": "1.0.0",
   "license": "UNLICENSED","dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "2025-10"
+    "@shopify/ui-extensions": "2026-04"
   }}

--- a/extensions/issue-tracker-block/shopify.d.ts
+++ b/extensions/issue-tracker-block/shopify.d.ts
@@ -5,3 +5,9 @@ declare module "./src/BlockExtension.jsx" {
   const shopify: import("@shopify/ui-extensions/admin.product-details.block.render").Api;
   const globalThis: { shopify: typeof shopify };
 }
+
+//@ts-ignore
+declare module "./src/BlockExtension-connect.jsx" {
+  const shopify: import("@shopify/ui-extensions/admin.product-details.block.render").Api;
+  const globalThis: { shopify: typeof shopify };
+}

--- a/extensions/issue-tracker-block/shopify.extension.toml
+++ b/extensions/issue-tracker-block/shopify.extension.toml
@@ -1,5 +1,5 @@
 # [START block-extension.configuration]
-api_version = "2025-10"
+api_version = "2026-04"
 
 [[extensions]]
 # Change the merchant-facing name of the extension in locales/en.default.json

--- a/extensions/issue-tracker-block/src/BlockExtension-connect.jsx
+++ b/extensions/issue-tracker-block/src/BlockExtension-connect.jsx
@@ -136,7 +136,7 @@ function Extension() {
                             label={i18n.translate("status-column-heading")}
                             value={completed ? "completed" : "todo"}
                             onChange={(event) =>
-                              handleChange(id, event.target.value)
+                              handleChange(id, (/** @type {HTMLInputElement} */ (event.target)).value)
                             }
                           >
                             <s-option value="todo">

--- a/extensions/issue-tracker-block/src/BlockExtension-connect.jsx
+++ b/extensions/issue-tracker-block/src/BlockExtension-connect.jsx
@@ -134,7 +134,7 @@ function Extension() {
                           <s-select
                             labelAccessibilityVisibility="exclusive"
                             label={i18n.translate("status-column-heading")}
-                            defaultValue={completed ? "completed" : "todo"}
+                            value={completed ? "completed" : "todo"}
                             onChange={(event) =>
                               handleChange(id, event.target.value)
                             }

--- a/extensions/issue-tracker-conditional-action/package.json
+++ b/extensions/issue-tracker-conditional-action/package.json
@@ -5,6 +5,6 @@
   "license": "UNLICENSED",
   "dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "2025-10"
+    "@shopify/ui-extensions": "2026-04"
   }
 }

--- a/extensions/issue-tracker-conditional-action/shopify.extension.toml
+++ b/extensions/issue-tracker-conditional-action/shopify.extension.toml
@@ -1,4 +1,4 @@
-api_version = "2025-10"
+api_version = "2026-04"
 [[extensions]]
 name = "t:name"
 handle = "conditional-admin-action-extension"

--- a/extensions/issue-tracker-conditional-action/src/ActionExtension.jsx
+++ b/extensions/issue-tracker-conditional-action/src/ActionExtension.jsx
@@ -68,7 +68,7 @@ export default async () => {
             formErrors?.title ? i18n.translate("issue-title-error") : undefined
           }
           onChange={(event) =>
-            setIssue((prev) => ({ ...prev, title: event.target.value }))
+            setIssue((prev) => ({ ...prev, title: (/** @type {HTMLInputElement} */ (event.target)).value }))
           }
           label={i18n.translate("issue-title-label")}
           maxLength={50}
@@ -82,7 +82,7 @@ export default async () => {
                 : undefined
             }
             onChange={(event) =>
-              setIssue((prev) => ({ ...prev, description: event.target.value }))
+              setIssue((prev) => ({ ...prev, description: (/** @type {HTMLInputElement} */ (event.target)).value }))
             }
             label={i18n.translate("issue-description-label")}
             max-length={300}

--- a/extensions/issue-tracker-conditional-action/src/ActionExtension.jsx
+++ b/extensions/issue-tracker-conditional-action/src/ActionExtension.jsx
@@ -56,10 +56,10 @@ export default async () => {
 
     return (
       <s-admin-action heading={i18n.translate("create-issue-heading")}>
-        <s-button slot="primaryAction" onClick={onSubmit}>
+        <s-button slot="primary-action" onClick={onSubmit}>
           {i18n.translate("issue-create-button")}
         </s-button>
-        <s-button slot="secondaryActions" onClick={close}>
+        <s-button slot="secondary-actions" onClick={close}>
           {i18n.translate("issue-cancel-button")}
         </s-button>
         <s-text-field

--- a/extensions/issue-tracker-conditional-action/src/condition/shouldRender.js
+++ b/extensions/issue-tracker-conditional-action/src/condition/shouldRender.js
@@ -1,5 +1,3 @@
-/// <reference types="../../../../shopify.d.ts" />
-
 // [START conditional-action-extension.module]
 import { getVariantsCount } from "../utils";
 

--- a/extensions/issue-tracker-conditional-block/package.json
+++ b/extensions/issue-tracker-conditional-block/package.json
@@ -5,6 +5,6 @@
   "license": "UNLICENSED",
   "dependencies": {
     "preact": "^10.10.x",
-    "@shopify/ui-extensions": "2025-10"
+    "@shopify/ui-extensions": "2026-04"
   }
 }

--- a/extensions/issue-tracker-conditional-block/shopify.extension.toml
+++ b/extensions/issue-tracker-conditional-block/shopify.extension.toml
@@ -1,4 +1,4 @@
-api_version = "2025-10"
+api_version = "2026-04"
 [[extensions]]
 # Change the merchant-facing name of the extension in locales/en.default.json
 name = "t:name"

--- a/extensions/issue-tracker-conditional-block/src/BlockExtension.jsx
+++ b/extensions/issue-tracker-conditional-block/src/BlockExtension.jsx
@@ -136,7 +136,7 @@ export default async () => {
                             labelAccessibilityVisibility="exclusive"
                             label={i18n.translate("select-label")}
                             value={completed ? "completed" : "todo"}
-                            onChange={(e) => handleChange(id, e.target.value)}
+                            onChange={(e) => handleChange(id, (/** @type {HTMLInputElement} */ (e.target)).value)}
                           >
                             <s-option value="todo">
                               {i18n.translate("option-todo")}
@@ -191,7 +191,7 @@ export default async () => {
     // Only render the block body if there is more than one variant, otherwise, return null to collapse the block
     return (
       <s-admin-block
-        title={i18n.translate("name")}
+        heading={i18n.translate("name")}
         collapsedSummary={
           !shouldRender ? i18n.translate("collapsed-summary") : null
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,8 +111,8 @@ importers:
   extensions/admin-print:
     dependencies:
       '@shopify/ui-extensions':
-        specifier: 2025-10
-        version: 0.0.0-2025-10-rc-20250429184054
+        specifier: 2026-04
+        version: 2026.4.2(@preact/signals@2.0.3(preact@10.26.5))(preact@10.26.5)
       preact:
         specifier: ^10.10.x
         version: 10.26.5
@@ -120,8 +120,8 @@ importers:
   extensions/issue-tracker-action:
     dependencies:
       '@shopify/ui-extensions':
-        specifier: 2025-10
-        version: 0.0.0-2025-10-rc-20250429184054
+        specifier: 2026-04
+        version: 2026.4.2(@preact/signals@2.0.3(preact@10.26.5))(preact@10.26.5)
       preact:
         specifier: ^10.10.x
         version: 10.26.5
@@ -129,8 +129,8 @@ importers:
   extensions/issue-tracker-block:
     dependencies:
       '@shopify/ui-extensions':
-        specifier: 2025-10
-        version: 0.0.0-2025-10-rc-20250429184054
+        specifier: 2026-04
+        version: 2026.4.2(@preact/signals@2.0.3(preact@10.26.5))(preact@10.26.5)
       preact:
         specifier: ^10.10.x
         version: 10.26.5
@@ -138,8 +138,8 @@ importers:
   extensions/issue-tracker-conditional-action:
     dependencies:
       '@shopify/ui-extensions':
-        specifier: 2025-10
-        version: 0.0.0-2025-10-rc-20250429184054
+        specifier: 2026-04
+        version: 2026.4.2(@preact/signals@2.0.3(preact@10.26.5))(preact@10.26.5)
       preact:
         specifier: ^10.10.x
         version: 10.26.5
@@ -147,8 +147,8 @@ importers:
   extensions/issue-tracker-conditional-block:
     dependencies:
       '@shopify/ui-extensions':
-        specifier: 2025-10
-        version: 0.0.0-2025-10-rc-20250429184054
+        specifier: 2026-04
+        version: 2026.4.2(@preact/signals@2.0.3(preact@10.26.5))(preact@10.26.5)
       preact:
         specifier: ^10.10.x
         version: 10.26.5
@@ -1249,8 +1249,16 @@ packages:
   '@shopify/storefront-api-client@1.0.9':
     resolution: {integrity: sha512-vgc0ZczMvrbsQQFYcIIONnIiqiafpcMyq5osI8X6PB65DhnmCQEp3kSlXKOjBPzyAWYvp28nLHS0+r4xsp4yQA==}
 
-  '@shopify/ui-extensions@0.0.0-2025-10-rc-20250429184054':
-    resolution: {integrity: sha512-uW5ehsgamZF4/hgWAPAenz3nZr43pP0qoBixSDF4V2QL5Qk6GA4amZsIfvIgvIi53RQCWwJ7KMpKg/LRmALuoA==}
+  '@shopify/ui-extensions@2026.4.2':
+    resolution: {integrity: sha512-EQN9zxtD3WKjk8Y1+wMzgzb7QZhiGGB+xmCWGVxvLxOfopz3uNukbloxj6ZH2Xl2KZeS88kuzdjTksFB2vo2fw==}
+    peerDependencies:
+      '@preact/signals': '*'
+      preact: '*'
+    peerDependenciesMeta:
+      '@preact/signals':
+        optional: true
+      preact:
+        optional: true
 
   '@ts-morph/common@0.26.1':
     resolution: {integrity: sha512-Sn28TGl/4cFpcM+jwsH1wLncYq3FtN/BIpem+HOygfBWPT5pAeS5dB4VFVzV8FbnOKHpDLZmvAl4AjPEev5idA==}
@@ -5181,7 +5189,7 @@ snapshots:
     dependencies:
       '@shopify/graphql-client': 1.4.1
 
-  '@shopify/ui-extensions@0.0.0-2025-10-rc-20250429184054':
+  '@shopify/ui-extensions@2026.4.2(@preact/signals@2.0.3(preact@10.26.5))(preact@10.26.5)':
     dependencies:
       ts-morph: 25.0.1
     optionalDependencies:


### PR DESCRIPTION
## Summary

### Runtime bugs fixed
- **Wrong slot names** across all action extension files — `slot="primaryAction"` → `slot="primary-action"`, `slot="secondaryActions"` → `slot="secondary-actions"`. Wrong slot names meant buttons weren't rendering in the correct modal positions.
- **`defaultValue` on `<s-select>` is not a valid prop** — replaced with controlled `value` in `BlockExtension-connect.jsx`. The initial selection was silently not being set.
- **`title` → `heading` on `<s-admin-action>` and `<s-admin-block>`** — renamed in the 2026-04 API; the old prop was silently ignored.
- **Stray `{ {` in `ActionExtension-backend.jsx`** — syntax error in the default export.
- **i18n key mismatches** in `-connect` and `-backend` variants — wrong keys like `create-button` fixed to `issue-create-button`, `issue-cancel-button`, `issue-save-button`.

### Version upgrade
- **`@shopify/ui-extensions` upgraded to `2026-04`** in all 5 extension `package.json` files — the previous `2025-10` resolved to a broken RC (`0.0.0-2025-10-rc-*`). Now resolves to `2026.4.2`.
- **`api_version = "2026-04"`** in all 5 `shopify.extension.toml` files.

### TypeScript errors fixed
- **`TS2339`** — `event.target.value` not valid on `EventTarget` — fixed with JSDoc cast `(/** @type {HTMLInputElement} */ (event.target)).value` across all `onChange` handlers (10 occurrences, 6 files).
- **`TS2304`** — `Cannot find name 'shopify'` in `-connect` and `-backend` variants — added module declarations to `shopify.d.ts` for `issue-tracker-action` and `issue-tracker-block`.
- **`TS2688`** — invalid `/// <reference types="../../../../shopify.d.ts" />` in `shouldRender.js` — removed (types already declared in the extension's `shopify.d.ts`).
- **`TS2345`** — `CallbackEvent<"s-checkbox">` passed directly to `setState` in `admin-print` — fixed by extracting `event.target.checked`.

## Test plan

- [ ] Launch the issue tracker action extension and verify Save/Cancel and Create/Cancel buttons appear in the correct modal slots
- [ ] Open an issue for editing from the block and verify the status select shows the correct initial value
- [ ] Verify the issue tracker action modal title renders (tests the `heading` prop rename)
- [ ] Run `node_modules/.bin/tsc -p extensions/<ext>/tsconfig.json --noEmit` for each extension — no source-file errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)